### PR TITLE
Optimize api image build

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-API_VERSION=v1.0-beta.0
+API_VERSION=v1.0-beta.1
 API_REMOTE=ghcr.io/snypy/snypy-backend
 STATIC_REMOTE=ghcr.io/snypy/snypy-static
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,13 +1,15 @@
+# https://hub.docker.com/alpine/git
+FROM alpine/git as src
+ARG GIT_HASH="master"
+WORKDIR /code
+RUN git clone https://github.com/nezhar/snypy-backend --single-branch --branch $GIT_HASH .
+
 # https://hub.docker.com/_/python
 FROM python:3.10-slim
-ARG GIT_HASH="master"
-RUN apt-get update && apt-get install git -y
-WORKDIR /usr/src/app
-RUN git clone https://github.com/nezhar/snypy-backend .
-RUN git checkout $GIT_HASH
-RUN pip install pip -U
-RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install gunicorn psycopg2-binary
-
+COPY --from=src /code/snypy /usr/src/app/snypy
+COPY --from=src /code/requirements.txt /usr/src/app/snypy/requirements.txt
 WORKDIR /usr/src/app/snypy
+RUN pip install --no-cache-dir pip gunicorn psycopg2-binary -U
+RUN pip install --no-cache-dir -r requirements.txt
+
 EXPOSE 8000


### PR DESCRIPTION
This PR introduces some optimization that decrease the api image with about 1/3 in disk size by using a multi-stage build for cloning the code:

| Image | Version | Size | 
|---|---|---|
| ghcr.io/snypy/snypy-backend | v1.0-beta.1 | 193MB |
| ghcr.io/snypy/snypy-backend | v1.0-beta.0 | 299MB |