### PR TITLE
Fixes id of dotenv action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
         if: env.SKIP != 1
 
       - name: Dotenv Action
+        id: dotenv
         uses: falti/dotenv-action@v1.0.4
         with:
           log-variables: true


### PR DESCRIPTION
Add an `id` to the `Dotenv Action` in order to be able to refference the loaded vars.