### PR TITLE
Update requirements path for rest api

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,7 +7,7 @@ RUN git clone https://github.com/nezhar/snypy-backend --single-branch --branch $
 # https://hub.docker.com/_/python
 FROM python:3.10-slim
 COPY --from=src /code/snypy /usr/src/app/snypy
-COPY --from=src /code/requirements.txt /usr/src/app/snypy/requirements.txt
+COPY --from=src /code/requirements/base.txt /usr/src/app/snypy/requirements.txt
 WORKDIR /usr/src/app/snypy
 RUN pip install --no-cache-dir pip gunicorn psycopg2-binary -U
 RUN pip install --no-cache-dir -r requirements.txt

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,7 +1,7 @@
 # https://hub.docker.com/_/python
 FROM python:3.10-slim
 WORKDIR /usr/src/app/snypy
-COPY /code/snypy-backend/requirements.txt /usr/src/app/snypy/requirements.txt
+COPY /code/snypy-backend/requirements/base.txt /usr/src/app/snypy/requirements.txt
 RUN pip install --no-cache-dir pip gunicorn psycopg2-binary -U
 RUN pip install --no-cache-dir -r requirements.txt
 

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /usr/src/app
 RUN git clone https://github.com/nezhar/snypy-backend .
 RUN git checkout $GIT_HASH
 RUN pip install pip -U
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements/base.txt
 
 WORKDIR /usr/src/app/snypy
 ENV SECRET_KEY=static


### PR DESCRIPTION
Adds an adaption for https://github.com/snypy/snypy-backend/pull/170 in order to build the container without dev and test dependencies.